### PR TITLE
Updated Lucene version to 6.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>luke</groupId>
     <artifactId>luke</artifactId>
-    <version>6.2.1</version>
+    <version>6.3.0</version>
 
     <properties>
         <jdk.version>1.8</jdk.version>


### PR DESCRIPTION
Apart from updating the version number in the POM, no further changes appear to be necessary.